### PR TITLE
Remove AI Studio reference from README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
-# Run and deploy your AI Studio app
+# Run and deploy your app
 
-This contains everything you need to run your app locally.
+This repository contains everything you need to run the app locally.
 
 ## Run Locally
 


### PR DESCRIPTION
## Summary
- update README heading and intro to remove AI Studio references

## Testing
- `npm run build` *(fails: Could not resolve "./contexts/DataProvider" from index.tsx)*

------
https://chatgpt.com/codex/tasks/task_e_684561363b18832fab6ab26705c9f9ce